### PR TITLE
CMakeLists.txt: fix build without C++

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 2.8)
-project(tutf8e)
+project(tutf8e C)
 
 # Not supported: -std=c90 (lacks support for inline)
 # Supported:     -std=gnu90, -std=c99 or -std=gnu99


### PR DESCRIPTION
tutf8e is written in c, so only enforce a c compiler

Seen while compiling fluent-bit on buildroot.